### PR TITLE
Autoload should be relative to project folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "autoload": {
         "classmap": [
-            "vendor/phery/phery/Phery.php"
+            "Phery.php"
         ]
     },
     "suggest": {


### PR DESCRIPTION
Currently updating composer would fail:

```
[RuntimeException]                                                                                                                                              
  Could not scan for classes inside "/user/workspace/project/vendor/phery/phery/vendor/phery/phery/Phery.php" which does not appear to  
   be a file nor a folder 
```